### PR TITLE
refactor: remove global BQDoctorService singleton

### DIFF
--- a/app/api/v1/rank.py
+++ b/app/api/v1/rank.py
@@ -1,12 +1,11 @@
 from fastapi import APIRouter, Depends
 from ...models.schemas import RankRequest, RankResponse
 from ...services.ranker import rank_candidates
-from ...deps import get_elastic
 
 router = APIRouter()
 
 
 @router.post("/rank", response_model=RankResponse)
-def rank(req: RankRequest, es=Depends(get_elastic)):
-    ranked = rank_candidates(req, es=es)
+def rank(req: RankRequest):
+    ranked = rank_candidates(req)
     return RankResponse(ranked=ranked)

--- a/app/deps.py
+++ b/app/deps.py
@@ -1,78 +1,39 @@
-######################
-# Dependencies to reuse
-######################
-
-# from elasticsearch import Elasticsearch
-# from .config import settings
-
-# _es_client: Elasticsearch | None = None
-
-# def get_elastic() -> Elasticsearch:
-#     global _es_client
-#     if _es_client is None:
-#         api_key = settings.ELASTIC_API_KEY
-#         kwargs = {"hosts": [settings.ELASTIC_URL]}
-#         if api_key:
-#             kwargs["api_key"] = api_key
-#         _es_client = Elasticsearch(**kwargs)
-#     return _es_client
-
 from elasticsearch import Elasticsearch
 from app.config import settings
 from app.services.chat_service import GenAIChatService, get_chat_service as _get_chat_service
 from app.services.speech_service import SpeechToTextService, get_speech_service as _get_speech_service
 from typing import Any, Generator
+from google.cloud import bigquery
+from google.auth import default
+
 import logging
 
-logger = logging.getLogger(__name__)
-
-# Global variable to hold the client instance (if needed for singleton pattern)
-_es_client = None
+_logger = logging.getLogger(__name__)
+_bq_client: bigquery.Client | None = None
 
 
-def get_elastic() -> Generator[Any, None, None]:
-    """
-    Dependency resolver that attempts to yield a live Elasticsearch client.
-    
-    If the connection fails (e.g., Elastic is not yet ready), it yields None 
-    and logs the error, allowing the FastAPI service to start (using mock search).
-    """
-    global _es_client
+# fastAPI dependency to yield a shared BQ client per process
+# safe to reuse across requests and threads, each worker has own instance.
+def get_bq() -> Generator[bigquery.Client, None, None]:
+    global _bq_client
+    if _bq_client is None:
+        creds, project = default()
+        _bq_client = bigquery.Client(project=project
+                                     or settings.GCP_PROJECT_ID,
+                                     credentials=creds)
+        _logger.info("Initialized global BigQuery client.")
+    yield _bq_client
 
-    # 1. MOCK/LIVE CHECK: If client is already initialized, use it
-    if _es_client is not None:
-        yield _es_client
-        return
 
-    # 2. ATTEMPT LIVE CONNECTION
-    try:
-        api_key = settings.ELASTIC_API_KEY
-        # NOTE: Your docker-compose maps port 9200 to elastic-local:9200
-        # For deployment, this will be the Cloud Elastic URL.
-        kwargs = {"hosts": [settings.ELASTIC_URL]}
-
-        if api_key:
-            kwargs["api_key"] = api_key
-
-        client = Elasticsearch(**kwargs)
-        client.info()  # Test the connection
-
-        logger.info("Successfully connected to live Elasticsearch.")
-        _es_client = client
-        yield client
-
-    except Exception as e:
-        logger.warning(
-            f"Failed to connect to Elasticsearch. Search endpoints will be MOCKED. Error: {e}"
-        )
-
-        # 3. YIELD MOCK: Yield None (or a dummy object) to allow the app to start
-        # The search endpoint's mock function (hybrid_search) is designed to handle this None client.
-        yield None
-
-    finally:
-        # FastAPI cleanup logic is typically handled implicitly or by using yield.
-        pass
+# for non-FastAPI code paths (scripts/jobs)
+def get_bq_sync() -> bigquery.Client:
+    global _bq_client
+    if _bq_client is None:
+        creds, project = default()
+        _bq_client = bigquery.Client(project=project
+                                     or settings.GCP_PROJECT_ID,
+                                     credentials=creds)
+    return _bq_client
 
 
 def get_chat_service() -> GenAIChatService:

--- a/app/services/bq_doctor_service.py
+++ b/app/services/bq_doctor_service.py
@@ -1,16 +1,12 @@
 from google.cloud import bigquery
 import json
 from app.config import settings
-from google.auth import default
 
 
 class BQDoctorService:
 
-    def __init__(self):
-        credentials, project = default()
-        self.client = bigquery.Client(project=project
-                                      or settings.GCP_PROJECT_ID,
-                                      credentials=credentials)
+    def __init__(self, client: bigquery.Client):
+        self.client = client
         self.table = f"{settings.GCP_PROJECT_ID}.{settings.BQ_CURATED_DATASET}.{settings.BQ_PROFILES_TABLE}"
 
     def _ensure_list(self, v):
@@ -87,6 +83,3 @@ class BQDoctorService:
 
             out.append(d)
         return out
-
-
-bq_doctor_service = BQDoctorService()

--- a/jobs/indexer.py
+++ b/jobs/indexer.py
@@ -9,15 +9,14 @@ from google.cloud import bigquery
 from app.config import settings
 from app.services.gemini_client import GeminiClient
 from app.services.web_search import web_search_client, WebSearchClient
+from app.deps import get_bq_sync
 import time
 
-BQ_CLIENT = bigquery.Client(project=settings.GCP_PROJECT_ID)
+BQ_CLIENT = get_bq_sync()
 GEMINI_CLIENT = GeminiClient()
 
 OUT_DIR = os.environ.get("INDEXER_OUT_DIR", "./out")
 os.makedirs(OUT_DIR, exist_ok=True)
-
-# ELASTIC_CLIENT = ElasticClient()
 
 
 def _timestamp() -> str:
@@ -264,34 +263,6 @@ def load_data_to_bq(enriched_data: List[Dict[str, Any]],
                 time.sleep(sleep_s)
 
     print(f"-> Successfully loaded {total} records into BigQuery.")
-
-
-# def load_data(enriched_data: List[Dict[str, Any]]):
-#     """Writes data to BigQuery and ElasticSearch"""
-
-#     # BQ write
-#     table_id = f"{settings.GCP_PROJECT_ID}.{settings.BQ_CURATED_DATASET}.{settings.BQ_PROFILES_TABLE}"
-#     try:
-#         # BQ insert_rows_json expects python dictionaries
-#         errors = BQ_CLIENT.insert_rows_json(table_id, enriched_data)
-#         if errors:
-#             print(f"WARNING: Errors occurred inserting data into BQ: {errors}")
-#         else:
-#             print(
-#                 f"-> Successfully loaded {len(enriched_data)} records into BigQuery table {table_id}."
-#             )
-#     except Exception as e:
-#         print(f"FATAL ERROR during BQ Load: {e}")
-#         return
-
-#     # elastic Upsert
-#     try:
-#         # ELASTIC_CLIENT.bulk_upsert(enriched_data, index_name=settings.ELASTIC_INDEX_DOCTORS)
-#         print(
-#             f"-> Indexed {len(enriched_data)} records into ElasticSearch index {settings.ELASTIC_INDEX_DOCTORS} (Placeholder)."
-#         )
-#     except Exception as e:
-#         print(f"WARNING: Errors occurred during Elastic Upsert: {e}")
 
 
 def run_indexer_job():


### PR DESCRIPTION
refactor: switch BQDoctorService to dependency injection pattern
- remove module-level singleton instance
- initialize BQDoctorService inside /doctors route using injected BigQuery client
- ensure BigQuery client is managed as a per-process singleton via get_bq()
-
refactor: centralize BigQuery client management and remove service singleton
- use get_bq()/get_bq_sync for all BQ access
- remove global bq_doctor_service instance
- update search route and jobs to inject client instead
