### PR TITLE
update npi registry connector, changing configuration to be dynamic

### DIFF
--- a/connectors/npi_registry/configuration.json
+++ b/connectors/npi_registry/configuration.json
@@ -4,7 +4,7 @@
   "request_timeout_seconds": 30,
   "request_backoff_seconds": 0.25,
   "max_pages_per_sync": 20,
-  "nyc_zip_prefixes": [
+  "zip_prefixes": [
     "100",
     "101",
     "102",

--- a/connectors/npi_registry/connector.py
+++ b/connectors/npi_registry/connector.py
@@ -1,22 +1,40 @@
+##############################################################
+# Fivetran Custom Connector SDK: NPI Registry Provider Data
+# Purpose:
+# Fetches NPI (National Provider Identifier) data for healthcare providers from the
+# NPPES NPI Registry API (CMS). This connector is designed to be highly configurable
+# to target specific states, postal code areas, and medical specialties.
+
+# Best Practices Implementation:
+# 1. Sharding: Uses multi-dimensional looping over postal prefixes and taxonomy codes
+#    to overcome the NPI API's 1200-record per-query limit.
+# 2. Incrementality: Uses the NPI 'last_updated_epoch' field as a bookmark for
+#    efficient incremental synchronization.
+# 3. Resilience: Includes exponential backoff and retry logic for transient API failures.
+# 4. Resumption: Uses 'last_processed_shard_key' to ensure syncs can resume exactly
+#    where they left off after a failure.
+##############################################################
+
 import json
 from datetime import datetime, timezone
 import time
 import typing as t
 import requests as rq
 
-from fivetran_connector_sdk import Connector  # Connector(update, schema)
-from fivetran_connector_sdk import Operations as op  # upsert(), checkpoint()
-from fivetran_connector_sdk import Logging as log  # log.info/fin e/warning/severe
+from fivetran_connector_sdk import Connector
+from fivetran_connector_sdk import Operations as op
+from fivetran_connector_sdk import Logging as log
 
-DEFAULT_NYC_ZIP_PREFIXES = [
-    "100", "101", "102", "103", "104", "111", "112", "113", "114", "116"
-]
-DEFAULT_TAXONOMY_DESCRIPTIONS = [
-    "Reproductive Endocrinology", "Orthopaedic Surgery"
-]
-DEFAULT_TAXONOMY_CODES = ["207VE0102X", "207X00000X"]
+# ------- config -------
 
-# ---------- helpers ---------
+API_VERSION = "2.1"
+# doctor practice location
+ADDRESS_PURPOSE = "location"
+DEFAULT_MAX_RETRIES = 5
+RETRY_BACKOFF = 2.0
+DEFAULT_STATE = "NY"
+
+# ------ helpers ------
 
 
 def _safe(d: dict, path: t.List[t.Union[str, int]], default=None):
@@ -80,7 +98,7 @@ def extract_last_name(r: dict) -> t.Optional[str]:
 
 
 def extract_last_updated_epoch(r: dict) -> t.Optional[int]:
-    return r.get("last_updated_epoch")  # provided by NPI API
+    return r.get("last_updated_epoch")
 
 
 def epoch_to_iso(epoch: t.Optional[int]) -> t.Optional[str]:
@@ -103,13 +121,120 @@ def is_after_bookmark(record_epoch: t.Optional[int],
         return True
 
 
-# ---------- SDK functions----------
+def _build_params(page_size: int, skip: int, state: str,
+                  postal_prefix: t.Optional[str],
+                  taxonomy_code: t.Optional[str]) -> t.Dict[str, str]:
+    """
+    Dynamically builds the API request parameters based on shard filters.
+    """
+    params = {
+        "version": API_VERSION,
+        "limit": str(page_size),
+        "skip": str(skip),
+        "address_purpose": ADDRESS_PURPOSE,
+        "state": state,  # mandatory for sharding
+    }
+
+    if postal_prefix:
+        params["postal_code"] = f"{postal_prefix}*"
+
+    # NPI API accepts 'taxonomy_description' OR 'taxonomy',
+    if taxonomy_code:
+        params["taxonomy"] = taxonomy_code
+
+    return params
+
+
+def _request_with_retries(url: str, params: t.Dict[str, str], timeout_s: int,
+                          max_retries: int, retry_backoff: float,
+                          shard_label: str) -> rq.Response:
+    """HTTP request with exponential retry mechanism """
+    headers = {
+        "User-Agent":
+        "SmarterDoc NPI Connector (contact: yian.chen261@gmail.com) "
+    }
+
+    last_err = None
+    for i in range(max_retries):
+        try:
+            resp = rq.get(url,
+                          params=params,
+                          headers=headers,
+                          timeout=timeout_s)
+            resp.raise_for_status()
+            return resp
+        except rq.HTTPError as e:
+            if e.response.status_code == 400:
+                log.severe(
+                    f"NPI API 400 Error on shard {shard_label}: Query is too broad or invalid. Cannot retry."
+                )
+                raise
+
+            # Transient error: 429 (Rate Limit) or 5xx (Server Error). Retry.
+            last_err = e
+            log.warning(
+                f"Transient error ({e.response.status_code}) on shard {shard_label}. Retrying in {retry_backoff ** i:.1f}s..."
+            )
+            time.sleep(retry_backoff**i)
+        except Exception as e:
+            # Connection/Timeout error. Retry.
+            last_err = e
+            log.warning(
+                f"Connection error on shard {shard_label}. Retrying in {retry_backoff ** i:.1f}s..."
+            )
+            time.sleep(retry_backoff**i)
+
+    # If the loop finishes without success, raise the last error
+    raise RuntimeError(
+        f"Request failed for shard {shard_label} after {max_retries} retries: {last_err}"
+    )
+
+
+# only want NYC doctors
+def _fetch_page_filtered(
+    api_base: str,
+    page_size: int,
+    skip: int,
+    timeout_s: int,
+    max_retries: int,
+    retry_backoff: float,
+    state: str,
+    postal_prefix: t.Optional[str],
+    taxonomy_code: t.Optional[str],
+) -> list:
+    """
+    Filtered call using practice LOCATION, postal_code wildcard, and taxonomy_description.
+    API params reference (v2.1): city, state, postal_code(wildcard allowed), address_purpose, taxonomy_description, limit/skip.
+    """
+    url = api_base.rstrip("/") + "/"
+
+    params = _build_params(page_size, skip, state, postal_prefix,
+                           taxonomy_code)
+
+    shard_label = f"ZIP={postal_prefix or 'ALL'}, TAX={taxonomy_code or 'ALL'}"
+
+    headers = {
+        "User-Agent":
+        "SmarterDoc NPI Connector (contact: yian.chen261@gmail.com)"
+    }
+
+    resp = _request_with_retries(url=url,
+                                 params=params,
+                                 timeout_s=timeout_s,
+                                 max_retries=max_retries,
+                                 retry_backoff=retry_backoff,
+                                 shard_label=shard_label)
+
+    payload = resp.json() or {}
+    return payload.get("results", []) or []
+
+
+# ---------- fivetran SDK functions----------
 
 
 def schema(configuration: dict):
     """
-    Declare only the table + PK; let Fivetran infer other columns & types
-    (SDK best practice).
+    Declare table + PK; Fivetran infers other columns & types
     """
     return [
         {
@@ -118,111 +243,93 @@ def schema(configuration: dict):
         },
     ]
 
-    # def _fetch_page(api_base: str, limit: int, skip: int, timeout: int) -> list:
-    """
-    Call NPI Registry v2.1 with pagination. We keep filters client-side initially.
-    Docs: https://npiregistry.cms.hhs.gov/api-page
-    """
-    url = api_base.rstrip("/") + "/"
-    params = {"version": "2.1", "limit": limit, "skip": skip}
-    headers = {
-        "User-Agent": "SmarterDoc NPI Connector (contact: team@example.com)"
-    }
-    resp = rq.get(url, params=params, headers=headers, timeout=timeout)
-    resp.raise_for_status()
-    payload = resp.json() or {}
-    return payload.get("results", []) or []
-
-
-# only want NYC doctors
-def _fetch_page_filtered(
-    api_base: str,
-    limit: int,
-    skip: int,
-    timeout: int,
-    postal_prefix: str,
-    taxonomy_desc: str,
-) -> list:
-    """
-    Filtered call using practice LOCATION, postal_code wildcard, and taxonomy_description.
-    API params reference (v2.1): city, state, postal_code(wildcard allowed), address_purpose, taxonomy_description, limit/skip.
-    """
-    url = api_base.rstrip("/") + "/"
-    params = {
-        "version": "2.1",
-        "limit": limit,
-        "skip": skip,
-        "address_purpose": "location",  # practice location only
-        "postal_code": f"{postal_prefix}*",  # NYC ZIP block
-        "taxonomy_description": taxonomy_desc,  # specialty filter
-        "state": "NY",
-    }
-    headers = {
-        "User-Agent": "SmarterDoc NPI Connector (contact: team@example.com)"
-    }
-    resp = rq.get(url, params=params, headers=headers, timeout=timeout)
-    resp.raise_for_status()
-    payload = resp.json() or {}
-    return payload.get("results", []) or []
-
-
-def _passes_filters(r: dict, states: t.Optional[t.Set[str]],
-                    tax_codes: t.Optional[t.Set[str]]) -> bool:
-    if states:
-        st = (extract_state(r) or "").upper()
-        if st not in states:
-            return False
-    if tax_codes:
-        txy = choose_primary_taxonomy(r.get("taxonomies"))
-        code = (txy.get("code") if txy else None) or ""
-        if code not in tax_codes:
-            return False
-    return True
-
 
 def update(configuration: dict, state: dict):
-    log.info("npi_registry: starting sync (NYC + specific specialties only)")
+    """
+    update: This function is called by Fivetran in every sync.
+    Gets the 
+
+    Args:
+        configuration (dict): dict containing connection details
+        state (dict): dict containing state information from previous runs. 
+        State dictionary is empty for the first sync of full re-sync
+    """
+    log.info("npi_registry: starting sync")
 
     api_base = configuration.get("api_base",
                                  "https://npiregistry.cms.hhs.gov/api/")
     page_size = int(configuration.get("page_size", 200))
     timeout_s = int(configuration.get("request_timeout_seconds", 30))
+    max_retries = int(configuration.get("max_retries", DEFAULT_MAX_RETRIES))
+    retry_backoff = float(
+        configuration.get("retry_backoff_factor", RETRY_BACKOFF))
+    state_filter = configuration.get("state_filter", DEFAULT_STATE)
     backoff_s = float(configuration.get("request_backoff_seconds", 0.25))
+
+    # Optional limit
     max_pages = configuration.get("max_pages_per_sync")
     max_pages = int(max_pages) if max_pages not in (None, "") else None
 
-    # Configurable lists; fall back to safe NYC defaults
-    nyc_zip_prefixes = configuration.get("nyc_zip_prefixes",
-                                         DEFAULT_NYC_ZIP_PREFIXES)
-    taxonomy_codes = configuration.get("taxonomy_codes",
-                                       DEFAULT_TAXONOMY_CODES)
+    # Optional configurable fields
+    shard_zip_prefixes = configuration.get("postal_prefixes", []) or [""]
+    shard_taxonomy_codes = configuration.get("taxonomy_codes", []) or [""]
 
     bookmark_iso = state.get("last_updated_at")
     total_rows = 0
     shards_seen = 0
     pages = 0
 
-    for zip_prefix in nyc_zip_prefixes:
-        for tcode in taxonomy_codes:
+    # store state of outer loop for mid-synced failures to resume
+    last_processed_shard = state.get("last_processed_shard_key", None)
+
+    is_resuming = last_processed_shard is not None
+
+    # split connections into manageable units
+    for zip_prefix in shard_zip_prefixes:
+        for tcode in shard_taxonomy_codes:
             shards_seen += 1
+
+            # create descriptive unique key to resume from
+            current_shard_key = f"{state_filter}-{zip_prefix or 'ALL'}-{tcode or 'ALL'}"
+
+            # If resuming, skip shards until we reach the last successful one
+            if is_resuming and current_shard_key != last_processed_shard:
+                log.info(f"Skipping previous shard: {current_shard_key}")
+                continue
+
+            # Start processing from this point forward
+            log.info(f"Starting shard: {current_shard_key}")
+
             skip = 0
             while True:
                 if max_pages is not None and pages >= max_pages:
-                    log.info(f"stopping due to max_pages_per_sync={max_pages}")
-                    op.checkpoint(state={"last_updated_at": bookmark_iso})
-                    return
+                    log.warning(
+                        f"Stopping sync due to max_pages_per_sync={max_pages} limit."
+                    )
+                    # persist current shard as checkpoint
+                    op.checkpoint(
+                        state={
+                            "last_updated_at": bookmark_iso,
+                            "last_processed_shard_key": current_shard_key
+                        })
+                    return  # exit sync
 
                 results = _fetch_page_filtered(api_base, page_size, skip,
-                                               timeout_s, zip_prefix, tcode)
+                                               timeout_s, max_retries,
+                                               retry_backoff, state_filter,
+                                               zip_prefix, tcode)
                 pages += 1
+
                 if not results:
-                    break
+                    break  # end of current shard
 
                 for r in results:
                     rec_epoch = extract_last_updated_epoch(r)
+
+                    # incremental sync check
                     if bookmark_iso and not is_after_bookmark(
                             rec_epoch, bookmark_iso):
-                        continue
+                        continue  # Skip old record
 
                     record_iso = epoch_to_iso(rec_epoch)
                     row = {
@@ -239,25 +346,43 @@ def update(configuration: dict, state: dict):
                     if not row["npi"]:
                         continue
 
+                    # upsert row
                     op.upsert(table="npi_providers", data=row)
                     total_rows += 1
 
+                    # advance bookmark
                     if record_iso and (bookmark_iso is None
                                        or record_iso > bookmark_iso):
                         bookmark_iso = record_iso
 
+                # pagination check
                 if len(results) < page_size:
-                    break
-                skip += page_size
-                time.sleep(backoff_s)
+                    break  # end of this shard
 
-    op.checkpoint(state={"last_updated_at": bookmark_iso})
+                skip += page_size
+                time.sleep(backoff_s)  # Respect API Rate Limits
+
+            # Checkpoint the successful completion of the current shard
+            op.checkpoint(
+                state={
+                    "last_updated_at": bookmark_iso,
+                    "last_processed_shard_key": current_shard_key
+                })
+            log.info(f"Finished shard: {current_shard_key}")
+
+            # Reset resumption key after the successful shard completion
+            last_processed_shard = None
+
+    # final checkpoint
+    op.checkpoint(state={
+        "last_updated_at": bookmark_iso,
+        "last_processed_shard_key": None
+    })
     log.info(
-        f"npi_registry: shards={shards_seen}, pages={pages}, rows={total_rows}, bookmark={bookmark_iso}"
+        f"npi_registry: Sync complete. Shards seen={shards_seen}, pages={pages}, rows={total_rows}, final bookmark={bookmark_iso}"
     )
 
 
-# Connector object
 connector = Connector(update=update, schema=schema)
 
 if __name__ == "__main__":
@@ -266,4 +391,5 @@ if __name__ == "__main__":
             cfg = json.load(f)
     except FileNotFoundError:
         cfg = {}
+    # allows testing connector
     connector.debug(configuration=cfg)


### PR DESCRIPTION
This pull request completes the initial development of Connector A (npi_registry) by transforming the initial NPI extraction logic into a robust Fivetran custom Connector.

The primary focus was adding resilience (retries/backoff) and checkpointing (resumption logic) to ensure the connector can reliably sync large, sharded datasets and recover automatically from transient API failures or sync interruptions

### Key Changes

- Resilience: Implemented the _request_with_retries helper with exponential backoff (2.0 factor, up to 5 times) to handle temporary network errors or NPI Registry rate limits (429 status). 
- Optimizing Performance: Avoids total sync failure due to transient network issues.
- Resumption Introduced the last_processed_shard_key to the state object. If the sync fails mid-run, the next sync will skip previously completed ZIP/Taxonomy combinations and resume exactly where it left off. 
- Checkpoint Regularly: Saves sync progress every time a full shard completes, preventing wasted time on resyncing processed data.
- Configuration: Made the postal_prefixes and taxonomy_codes optional inputs. If left empty, the sync defaults to querying the entire State filter without applying those dimensions, simplifying configuration for broad queries. 
- Handle State Transitions / Fallback Values: Ensures the connector works robustly whether filters are provided or not.
- Incrementality: The connector continues to use the NPI record's last_updated_epoch as the primary bookmark, ensuring only new or updated records are processed. 
- Using State for Incremental Sync: Minimizes data processing volume and cost.
