### PR TITLE
correct doctor recommendation selection schema and logic

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -340,16 +340,28 @@ class FinalRecommendedDoctor(BaseModel):
     final_weighted_score: Optional[float] = None
     feature_scores: Optional[float] = None
     semantic_similarity_score: Optional[float] = None
+    # agent_reasoning_summary: str = Field(
+    #     default="",
+    #     description=
+    #     "The LLM-generated, concise justification (max 5 sentences) for why this doctor was selected."
+    # )
+
+
+class JustifiedDoctorOut(DoctorOut):
+    # Inherits all fields from DoctorOut
+    final_weighted_score: Optional[float] = None
+    feature_scores: Optional[float] = None
+    semantic_similarity_score: Optional[float] = None
     agent_reasoning_summary: str = Field(
         default="",
         description=
-        "The LLM-generated, concise justification (max 5 sentences) for why this doctor was selected."
+        "The model-generated, concise justification (max 5 sentences) for why this doctor was selected."
     )
 
 
 class FinalRecommendationList(BaseModel):
     """The container for the structured list of Top 3 doctors returned by the RAG Agent."""
-    recommendations: List[DoctorOut]
+    recommendations: List[JustifiedDoctorOut]
 
 
 class AgentSearchRequest(BaseModel):


### PR DESCRIPTION
1. Correct Doctor recommendation output schema for output consistency.
2. Update doctor selection logic to ensure better accuracy and higher quality recommendation. The original selection was randomly selecting the first 10 candidates after the semantic search using vector similarity search, but now we're passing in the full 30 and letting LLM model select the top 3, then concatenating with the rest of the 27 and ensuring the output fields align with the correct endpoint output schema.