### PR TITLE
fix: book appointment twiml url change

### DIFF
--- a/app/api/v1/telephony.py
+++ b/app/api/v1/telephony.py
@@ -5,9 +5,11 @@ Handles phone calls, TwiML generation, and WebSocket media streams.
 import json
 import asyncio
 from typing import Dict, Any
+import time
+from uuid import uuid4
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, HTTPException, Request
 from fastapi.responses import PlainTextResponse, Response
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from app.config import settings
 from app.util.logging import logger
@@ -54,38 +56,142 @@ class CallStatusResponse(BaseModel):
 # Helper Functions
 # ============================================
 
+class InstructionStore:
+    """In-memory instruction store with simple TTL eviction."""
+    def __init__(self, ttl_seconds: int = 600):
+        self._store: Dict[str, Dict[str, Any]] = {}
+        self._ttl = ttl_seconds
+
+    def set(self, token: str, instruction: str):
+        now = time.time()
+        self._store[token] = {"instruction": instruction, "ts": now}
+        self._prune()
+
+    def get(self, token: str) -> str | None:
+        data = self._store.get(token)
+        if not data:
+            return None
+        if time.time() - data["ts"] > self._ttl:
+            # expired
+            try:
+                del self._store[token]
+            except KeyError:
+                pass
+            return None
+        return data["instruction"]
+
+    def _prune(self):
+        now = time.time()
+        expired = [k for k, v in self._store.items() if now - v["ts"] > self._ttl]
+        for k in expired:
+            try:
+                del self._store[k]
+            except KeyError:
+                pass
+
+
+instruction_store = InstructionStore(ttl_seconds=600)
+
 def get_public_url(request: Request) -> str:
     """
     Get the public URL for this server.
     Uses X-Forwarded-Host header if available (for ngrok/Cloud Run).
     """
+    # Check for environment variable override (for ngrok development)
+    ngrok_url = getattr(settings, 'NGROK_URL', None)
+    if ngrok_url:
+        logger.info(f"get_public_url - Using NGROK_URL from settings: {ngrok_url}")
+        return ngrok_url
+    
     # Check for forwarded host (ngrok, Cloud Run, etc.)
     forwarded_host = request.headers.get("x-forwarded-host")
     forwarded_proto = request.headers.get("x-forwarded-proto", "https")
     
+    logger.info(f"get_public_url - forwarded_host: {forwarded_host}")
+    logger.info(f"get_public_url - forwarded_proto: {forwarded_proto}")
+    
     if forwarded_host:
-        return f"{forwarded_proto}://{forwarded_host}"
+        # For ngrok, use the forwarded host with https
+        if "ngrok" in forwarded_host or "ngrok-free" in forwarded_host:
+            result = f"https://{forwarded_host}"
+            logger.info(f"get_public_url - Using ngrok URL: {result}")
+            return result
+        # For Cloud Run, always use https
+        if ".run.app" in forwarded_host:
+            result = f"https://{forwarded_host}"
+            logger.info(f"get_public_url - Using Cloud Run URL: {result}")
+            return result
+        result = f"{forwarded_proto}://{forwarded_host}"
+        logger.info(f"get_public_url - Using forwarded URL: {result}")
+        return result
     
     # Fallback to request host
     host = request.headers.get("host", "localhost:8080")
+    logger.info(f"get_public_url - host: {host}")
+    
+    # For ngrok domains, always use https
+    if "ngrok" in host or "ngrok-free" in host:
+        result = f"https://{host}"
+        logger.info(f"get_public_url - Using ngrok host URL: {result}")
+        return result
+    
+    # For local development, use localhost
+    if "localhost" in host or "127.0.0.1" in host:
+        result = f"http://localhost:8080"
+        logger.info(f"get_public_url - Using localhost URL: {result}")
+        return result
+    
+    # For Cloud Run domains, always use https
+    if ".run.app" in host:
+        result = f"https://{host}"
+        logger.info(f"get_public_url - Using Cloud Run host URL: {result}")
+        return result
+    
+    # Default scheme detection
     scheme = "https" if "443" in host else "http"
-    return f"{scheme}://{host}"
+    result = f"{scheme}://{host}"
+    logger.info(f"get_public_url - Using default URL: {result}")
+    return result
 
 
-def generate_twiml(websocket_url: str) -> str:
+def generate_twiml(websocket_url: str, parameters: Dict[str, str] | None = None) -> str:
     """
     Generate TwiML for connecting a call to a WebSocket stream.
-    
-    Args:
-        websocket_url: WebSocket URL for media streaming
-        
-    Returns:
-        TwiML XML string
+    Optionally include <Parameter> elements that Twilio will echo in the
+    Media Streams 'start' event under customParameters.
+
+    IMPORTANT: TwiML is XML. Attribute values MUST be XML-escaped, especially
+    ampersands in query strings.
     """
+    def escape_attr(value: str) -> str:
+        if value is None:
+            return ""
+        # Escape XML attribute special characters
+        return (
+            str(value)
+            .replace("&", "&amp;")
+            .replace("\"", "&quot;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        )
+
+    # Escape URL for XML attribute context
+    safe_url = escape_attr(websocket_url)
+
+    params_xml = ""
+    if parameters:
+        for name, value in parameters.items():
+            if value is None:
+                continue
+            safe_name = escape_attr(name)
+            safe_value = escape_attr(value)
+            params_xml += f"\n            <Parameter name=\"{safe_name}\" value=\"{safe_value}\" />"
+
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
     <Connect>
-        <Stream url="{websocket_url}" />
+        <Stream url="{safe_url}">{params_xml}
+        </Stream>
     </Connect>
 </Response>"""
 
@@ -95,13 +201,32 @@ def generate_twiml(websocket_url: str) -> str:
 # ============================================
 
 @router.post("/call", response_model=CallResponse)
-async def initiate_call(request: Request, call_request: CallRequest):
+async def initiate_call(request: Request):
     """
     Initiate an outbound phone call.
     
     The call will be connected to a Vertex AI Live API session for voice interaction.
     """
     try:
+        # Check if this is a Twilio webhook (form data) or API call (JSON)
+        content_type = request.headers.get("content-type", "")
+        
+        if "application/x-www-form-urlencoded" in content_type or "multipart/form-data" in content_type:
+            # This is a Twilio webhook, redirect to /twiml endpoint
+            logger.info("Received Twilio webhook on /call, serving TwiML via /twiml")
+            return await get_twiml(request)
+
+        # This is a regular API call with JSON
+        try:
+            body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=422, detail="Expected JSON body for /call API requests")
+
+        try:
+            call_request = CallRequest(**body)
+        except ValidationError as ve:
+            raise HTTPException(status_code=422, detail=ve.errors())
+        
         # Check if Twilio is configured
         twilio_service = get_twilio_service()
         if not twilio_service.is_configured():
@@ -112,23 +237,27 @@ async def initiate_call(request: Request, call_request: CallRequest):
         
         # Get public URL for TwiML callback
         public_url = get_public_url(request)
+        logger.info(f"Telephony /call API - Public URL: {public_url}")
+        logger.info(f"Telephony /call API - Request headers: {dict(request.headers)}")
         
         # Build TwiML URL (with optional voice, system instruction, and initial message as query params)
         twiml_url = call_request.twiml_url
         if not twiml_url:
             twiml_url = f"{public_url}/api/v1/telephony/twiml"
-            
-            # Add query parameters for customization
+            # Add query parameters
             params = []
+            from urllib.parse import quote
             if call_request.voice:
-                params.append(f"voice={call_request.voice}")
+                params.append(f"voice={quote(call_request.voice)}")
+            # For long instructions, avoid putting raw text in URL; store and pass token
+            token: str | None = None
             if call_request.system_instruction:
-                # URL encode the system instruction
-                from urllib.parse import quote
-                params.append(f"instruction={quote(call_request.system_instruction)}")
-            
+                token = uuid4().hex
+                instruction_store.set(token, call_request.system_instruction)
+                params.append(f"token={quote(token)}")
             if params:
                 twiml_url += "?" + "&".join(params)
+            logger.info(f"Telephony /call API - Generated TwiML URL: {twiml_url}")
         
         # Initiate the call
         result = twilio_service.initiate_call(
@@ -198,7 +327,8 @@ async def hangup_call(call_sid: str):
 async def get_twiml(
     request: Request, 
     voice: str | None = None, 
-    instruction: str | None = None
+    instruction: str | None = None,
+    token: str | None = None,
 ):
     """
     Generate TwiML for Twilio to connect the call to our WebSocket.
@@ -208,33 +338,46 @@ async def get_twiml(
     - instruction: Optional system instruction (URL-encoded)
     """
     try:
-        # Get host from request
-        forwarded_host = request.headers.get("x-forwarded-host")
-        host = forwarded_host if forwarded_host else request.headers.get("host", "localhost:8080")
+        # Use the same get_public_url function for consistency
+        public_url = get_public_url(request)
         
-        # Determine WebSocket scheme
-        # Cloud Run uses https, so WebSocket should be wss
-        forwarded_proto = request.headers.get("x-forwarded-proto", "")
-        ws_scheme = "wss" if forwarded_proto == "https" or forwarded_host else "ws"
+        # Determine WebSocket scheme based on public URL
+        if public_url.startswith("https://"):
+            ws_scheme = "wss"
+            # Extract host from public URL
+            host = public_url.replace("https://", "")
+        else:
+            ws_scheme = "ws"
+            # Extract host from public URL
+            host = public_url.replace("http://", "")
         
         # Build WebSocket URL
         ws_url = f"{ws_scheme}://{host}/api/v1/telephony/twilio-stream"
         
         # Add query parameters if provided
         params = []
+        from urllib.parse import quote
         if voice:
-            params.append(f"voice={voice}")
+            params.append(f"voice={quote(voice)}")
         if instruction:
-            params.append(f"instruction={instruction}")
+            params.append(f"instruction={quote(instruction)}")
+        if token:
+            params.append(f"token={quote(token)}")
         
         if params:
             ws_url += "?" + "&".join(params)
         
-        # Generate TwiML
-        twiml = generate_twiml(ws_url)
+        # Generate TwiML with safe custom parameters for observability
+        custom_params = {}
+        if voice:
+            custom_params["voice"] = voice
+        if token:
+            custom_params["token"] = token
+        twiml = generate_twiml(ws_url, custom_params)
         
         logger.info(f"Generated TwiML with WebSocket URL: {ws_url}")
-        logger.info(f"Request headers - Host: {host}, Proto: {forwarded_proto}, Forwarded-Host: {forwarded_host}")
+        logger.info(f"TwiML API - Public URL: {public_url}")
+        logger.info(f"TwiML API - WebSocket scheme: {ws_scheme}")
         
         # Return TwiML with correct Content-Type
         return Response(
@@ -261,7 +404,8 @@ async def get_twiml(
 async def twilio_stream_websocket(
     websocket: WebSocket,
     voice: str | None = None,
-    instruction: str | None = None
+    instruction: str | None = None,
+    token: str | None = None,
 ):
     """
     WebSocket endpoint for Twilio Media Streams.
@@ -271,9 +415,10 @@ async def twilio_stream_websocket(
     - voice: Optional Vertex AI voice name
     - instruction: Optional system instruction
     """
-    logger.info(f"WebSocket connection attempt - Voice: {voice}, Instruction: {instruction}")
-    logger.info(f"WebSocket URL: {websocket.url}")
-    logger.info(f"WebSocket headers: {dict(websocket.headers)}")
+    logger.info(f"🔌 WebSocket connection attempt - Voice: {voice}, Instruction: {str(instruction)[:80] if instruction else None}, Token: {token}")
+    logger.info(f"🔌 WebSocket URL: {websocket.url}")
+    logger.info(f"🔌 WebSocket headers: {dict(websocket.headers)}")
+    logger.info(f"🔌 WebSocket client: {websocket.client}")
     
     try:
         await websocket.accept()
@@ -305,12 +450,30 @@ async def twilio_stream_websocket(
                     # Stream started
                     stream_sid = message["start"]["streamSid"]
                     call_sid = message["start"]["callSid"]
+                    # Extract custom parameters (voice/token) if present
+                    try:
+                        custom_params = message["start"].get("customParameters") or {}
+                        if not voice and custom_params.get("voice"):
+                            voice = custom_params.get("voice")
+                        if not token and custom_params.get("token"):
+                            token = custom_params.get("token")
+                    except Exception:
+                        pass
                     
                     logger.info(f"📞 Stream started - StreamSID: {stream_sid}, CallSID: {call_sid}")
                     logger.info("🤖 Starting Vertex Live AI session...")
                     
                     # Create Vertex Live session
-                    system_instruction_text = instruction or settings.VERTEX_LIVE_SYSTEM_INSTRUCTION
+                    # Resolve system instruction preference: explicit param > token store > default
+                    system_instruction_text = None
+                    if instruction:
+                        system_instruction_text = instruction
+                    elif token:
+                        system_instruction_text = instruction_store.get(token)
+                        if system_instruction_text is None:
+                            logger.warning(f"⚠️ Instruction token not found or expired: {token}")
+                    if not system_instruction_text:
+                        system_instruction_text = settings.VERTEX_LIVE_SYSTEM_INSTRUCTION
                     voice_name = voice or settings.VERTEX_LIVE_VOICE
                     
                     # Create Vertex Live session with system instruction
@@ -415,6 +578,40 @@ async def health_check():
         "vertex_model": settings.VERTEX_LIVE_MODEL,
         "vertex_voice": settings.VERTEX_LIVE_VOICE,
     }
+
+
+@router.get("/test-websocket")
+async def test_websocket_url(request: Request):
+    """
+    Test endpoint to verify WebSocket URL generation.
+    """
+    try:
+        public_url = get_public_url(request)
+        
+        # Determine WebSocket scheme based on public URL
+        if public_url.startswith("https://"):
+            ws_scheme = "wss"
+            host = public_url.replace("https://", "")
+        else:
+            ws_scheme = "ws"
+            host = public_url.replace("http://", "")
+        
+        ws_url = f"{ws_scheme}://{host}/api/v1/telephony/twilio-stream"
+        
+        return {
+            "status": "success",
+            "public_url": public_url,
+            "websocket_url": ws_url,
+            "websocket_scheme": ws_scheme,
+            "host": host
+        }
+        
+    except Exception as e:
+        logger.error(f"Error in test-websocket: {e}")
+        return {
+            "status": "error",
+            "error": str(e)
+        }
 
 
 @router.get("/test-twiml")

--- a/app/config.py
+++ b/app/config.py
@@ -74,6 +74,9 @@ class Settings(BaseSettings):
     TWILIO_ACCOUNT_SID: str | None = None
     TWILIO_AUTH_TOKEN: str | None = None
     TWILIO_NUMBER: str | None = None
+    
+    # ngrok URL for local development (override for WebSocket connections)
+    NGROK_URL: str | None = None
 
     # ============================================
     # Vertex AI Live API Configuration


### PR DESCRIPTION
# Telephony: Stabilize Twilio Media Streams, unify `/call`, safe long-instruction handling, and fix TwiML XML (12100)

## Summary
This PR makes telephony calling and real-time media stable across local (ngrok) and Cloud Run environments. It unifies how we initiate calls, ensures Twilio gets valid TwiML and a working WebSocket URL, and introduces a safe mechanism for passing long system instructions without breaking URLs. It also fixes 422 webhook mismatches and TwiML 12100 parse failures.

## Key Changes
- Telephony API (`app/api/v1/telephony.py`)
  - `/call`
    - Refactored to manually parse JSON for API calls and auto-handle Twilio webhooks (`application/x-www-form-urlencoded`) by serving `/twiml` directly (prevents 422 errors).
    - Generates TwiML URL using a robust `get_public_url()` with:
      - NGROK_URL override for dev
      - x-forwarded-host/proto support for Cloud Run
      - Host fallback with proper scheme
    - Long instruction tokenization:
      - Store full `system_instruction` in a TTL’d in-memory store (10 minutes) and pass only a short `token` in the URL.
      - Avoids URL-length issues and whitespace/newline breakage.
    - Detailed request logging for observability.
  - `/twiml`
    - Uses `get_public_url()` to derive public base and proper `wss://` vs `ws://`.
    - URL-encodes `voice`/`instruction` query params and adds `<Parameter name="voice" value="..."/>` and `<Parameter name="token" value="..."/>` in TwiML `<Stream>` for Twilio `customParameters`.
    - XML-escapes all attribute values (fixes 12100 Document parse failure when `&` exists in URL).
    - Returns correct `text/xml; charset=utf-8`.
  - WebSocket `/twilio-stream`
    - Accepts `voice`, `instruction`, and `token` from query params.
    - Extracts `customParameters` (`voice`, `token`) from Twilio Media Streams `start` event.
    - Resolves full system instruction in this precedence:
      1) explicit `instruction` query param
      2) `token` → in-memory store
      3) default from settings
    - Starts Vertex Live session and streams audio reliably; improved logging and cleanup.
  - Added `/test-websocket` diagnostic endpoint (reports computed `wss://` URL).
  - Hardened TwiML generator with XML attribute escaping for `url` and `<Parameter>` values.

- Appointment API (`app/api/v1/book.py`)
  - Now calls `/api/v1/telephony/call` instead of invoking Twilio directly.
  - In dev/ngrok only, injects `x-forwarded-host/proto` to emulate external requests.
  - Better HTTP error logging and visibility.

- Config (`app/config.py`)
  - New `NGROK_URL` setting to force public URL in development.
  - Notes for Cloud Run (auto-picks real host via forwarded headers; do not set `NGROK_URL` in prod).

## Bugs Fixed
- Twilio error 21205 (“Url is not a valid URL”) due to unencoded or localhost URLs.
- Twilio error 12100 (“Document parse failure”) due to unescaped `&` in TwiML XML attributes.
- 422 webhook mismatch when Twilio posts form data to `/call`.
- WebSocket not connecting when query params had whitespace/newlines or URL became too long.

## How to Use Long Instructions (safe)
- Send full text via `system_instruction` in the `/call` request payload (no size trimming required).
- Backend stores it and passes a short token in the URL; WebSocket resolves it on connect.
- This avoids URL length limits and any whitespace/newline issues.

## Local/Dev vs Production
- Local (ngrok):
  - Set `NGROK_URL=https://<your-ngrok>.ngrok-free.dev`
  - In `book.py`, dev path injects `x-forwarded-host/proto` headers to make internal calls behave as external.
- Production (Cloud Run):
  - Do not set `NGROK_URL`.
  - Remove the dev-only forwarded headers in `book.py` (or guard behind dev check).
  - Twilio ‘A CALL COMES IN’ Voice webhook → `POST https://<cloud-run-domain>/api/v1/telephony/twiml`.

## Testing Performed
- Local:
  - `/call` with JSON: creates call and returns `call_sid`.
  - Twilio webhook to `/twiml`: returns XML with `wss://.../twilio-stream?token=...` and `<Parameter>` entries.
  - WebSocket handshake verified (status 101 Switching Protocols).
  - Media stream start events show `customParameters` (voice, token) and session boot.
- ngrok:
  - Verified public URL derivation and WebSocket scheme (`wss://`).
  - Ensured no 12100 parse failures and no 21205 URL errors.
- Error handling:
  - Bad payload → 422 with structured validation errors.
  - Missing Twilio config → 503 with descriptive message.

## Deployment Notes
- Ensure environment variables on Cloud Run:
  - Unset `NGROK_URL` (prod).
  - Provide Twilio credentials via secrets.
  - Provide Vertex Live model/voice/system instruction via env.
- Update Twilio phone number Voice webhook:
  - A CALL COMES IN → Webhook → `POST https://<cloud-run-domain>/api/v1/telephony/twiml`
- After deploy, confirm logs show:
  - TwiML generated with `wss://<cloud-run-domain>/...`
  - WebSocket connection attempt and start event.

## Backward Compatibility
- `/call`, `/twiml`, and `/twilio-stream` remain at the same paths.
- Behavior is more robust; long instructions are now safe and transparent to callers.

## Risks & Mitigations
- In-memory instruction store is per instance with TTL (10 minutes):
  - Acceptable for dev/testing; for multi-instance prod and higher reliability, migrate to Redis/Cloud Memorystore and extend TTL.
- ngrok dependency:
  - Dev only. In prod, rely on Cloud Run forwarded headers.

## Checklist
- [x] Fix TwiML XML escaping (12100)
- [x] Fix invalid URL issues (21205)
- [x] Unify `/call` to handle JSON and Twilio webhook
- [x] Implement long-instruction tokenization
- [x] Encode query params and add `<Parameter>` for Twilio `customParameters`
- [x] Improve logs for public URL, TwiML, and WS lifecycle
- [x] Add `NGROK_URL` and docs for dev vs prod